### PR TITLE
Add action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ runs:
     - name: Check
       run: yarn rw check
       shell: bash
-    - name: Test
+    - name: Run tests
       run: yarn rw test
       shell: bash
     - name: Build

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,18 @@
+name: RedwoodJS CI
+description: RedwoodJS CI—lint, check, run tests, and build
+runs:
+  using: "composite"
+  steps:
+    # lint, run tests, and build
+    - name: Lint
+      run: yarn rw lint
+      shell: bash
+    - name: Check
+      run: yarn rw check
+      shell: bash
+    - name: Test
+      run: yarn rw test
+      shell: bash
+    - name: Build
+      run: yarn rw build
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,6 @@ description: RedwoodJS CI—lint, check, run tests, and build
 runs:
   using: "composite"
   steps:
-    # lint, run tests, and build
     - name: Lint
       run: yarn rw lint
       shell: bash


### PR DESCRIPTION
This PR adds a [composite action](https://docs.github.com/en/actions/creating-actions/about-actions#composite-run-steps-actions), meaning it just bundles up a bunch of steps that would ordinarily be listed in a job of a workflow. The action just performs redwood basics: lint, check, run tests, and build.

I'm not sure if a composite action will scale or not. We could always just make it a JS action from the get-go and use [@action/exec](https://github.com/actions/toolkit/tree/main/packages/exec) to do more or less the same thing. But as long as it's just those four steps (lint, check, run tests, and build), a composite action is way simpler since it's just a yaml file.

Things to consider:

- Jest takes a `--ci` flag; something about not saving snapshots from [it's description](https://jestjs.io/docs/cli#--ci). I'm guessing if we did update snapshots, we'd end up in an infinite CI loop (push to main triggers CI which pushes to main...). So I'm guessing we want this flag? Then again I've never added a snapshot to a Redwood App before so, not totally sure.
- Here's some evidence that jest handles watch mode in CI environments: https://jestjs.io/docs/cli#--watchall (but since it says "in most", I guess we should just pass it)
- There's "jest is super slow in my CI environment" troubleshooting docs: https://jestjs.io/docs/troubleshooting#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server. Not sure if we'll run into this but something to look out for 
- Not totally sure how to test this yet