### PR TITLE
[Prerender] Add migrate step, `DATABASE_URL` env var to build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,9 +58,18 @@ runs:
       run: yarn install --immutable
       shell: bash
       
+    - name: Run migrate
+      working-directory: ${{ steps.project-directory.outputs.dir }}
+      run: yarn rw prisma migrate dev
+      env:
+        DATABASE_URL: postgresql://test:password@localhost:5432/test
+      shell: bash
+      
     - name: Run Build
       working-directory: ${{ steps.project-directory.outputs.dir }}
       run: yarn rw build
+      env:
+        DATABASE_URL: postgresql://test:password@localhost:5432/test
       shell: bash
 
     - name: Run Lint


### PR DESCRIPTION
Fixing deploy target CI. Cell prerendering needs 1) the database to be migrated and seeded and 2) to know the `DATABASE_URL`.

Deploy target CI was failing on the prerender step. It couldn't prerender `BlogPostsQuery`:

```
Invalid `db.post.findMany()` invocation in /home/runner/work/deploy-target-ci/deploy-target-ci/vercel/api/src/services/posts/posts.ts:6:18

import { db } from 'src/lib/db'

export const posts = () => {
  return db.post.findMany() // 💥 
}

Authentication failed against database server at `localhost`, the provided database credentials for `postgres` are not valid.
Please make sure to provide valid database credentials for the database server at `localhost`
```

It's complaining it can't authenticate, and that's because the build step doesn't have the `DATABASE_URL` env var. But after you add it, you'll get a different error:

```
Invalid `db.post.findMany()` invocation in /home/runner/work/deploy-target-ci/deploy-target-ci/netlify/api/src/services/posts/posts.ts:6:18

import { db } from 'src/lib/db'

export const posts = () => {
  return db.post.findMany() // 💥 
}

The table `public.Post` does not exist in the current database.
```

This is because the database hasn't been migrated.

